### PR TITLE
Fix Dockerfile inference in nitrogen::build

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,12 +1,17 @@
 use failure::Error;
 use home;
 use std::env;
+use std::path::PathBuf;
 use std::process::Output;
 use tokio::process::Command;
 use tracing::instrument;
 
 #[instrument(level = "debug")]
 pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output, Error> {
+    let dockerdir = PathBuf::from(dockerfile_dir);
+    let mut dockerfile_path = PathBuf::from(dockerfile_dir);
+    dockerfile_path.push("Dockerfile");
+
     let out = Command::new("docker")
         .args([
             "build",
@@ -14,9 +19,9 @@ pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output,
             "nitrogen-build",
             "--platform",
             "linux/amd64",
-            dockerfile_dir,
+            dockerdir.to_str().unwrap(),
             "-f",
-            &format!("{}/.", dockerfile_dir),
+            dockerfile_path.to_str().unwrap(),
         ])
         .output()
         .await?;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Output;
 use tokio::process::Command;
-use tracing::{instrument, info};
+use tracing::{info, instrument};
 
 #[instrument(level = "debug")]
 pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output, Error> {
@@ -27,7 +27,10 @@ pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output,
         .await?;
     if !out.status.success() {
         let stderr_str = std::str::from_utf8(&out.stderr)?;
-        return Err(failure::err_msg(format!("Docker build error: {:#?}", stderr_str)));
+        return Err(failure::err_msg(format!(
+            "Docker build error: {:#?}",
+            stderr_str
+        )));
     }
 
     let h = home::home_dir().unwrap_or_default();
@@ -41,10 +44,7 @@ pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output,
             "-v",
             "/var/run/docker.sock:/var/run/docker.sock",
             "-v",
-            &format!(
-                "{}:/root/build",
-                eif_dir,
-            ),
+            &format!("{}:/root/build", eif_dir,),
             "capeprivacy/eif-builder:latest",
             "build-enclave",
             "--docker-uri",
@@ -56,7 +56,10 @@ pub async fn build(dockerfile_dir: &String, eif_name: &String) -> Result<Output,
         .await?;
     if !out.status.success() {
         let stderr_str = std::str::from_utf8(&out.stderr)?;
-        return Err(failure::err_msg(format!("Docker build error: {:#?}", stderr_str)));
+        return Err(failure::err_msg(format!(
+            "Docker build error: {:#?}",
+            stderr_str
+        )));
     } else {
         info!("EIF written to {}/{}.", eif_dir, &eif_name);
     }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -185,6 +185,7 @@ pub async fn deploy(
         memory.unwrap()
     };
 
+    info!("Using instance URL {}...", url);
     terminate_existing_enclaves(ssh_key, &url)?;
     update_allocator_memory(mem, ssh_key, &url)?;
     deploy_eif(eif, ssh_key, &url)?;


### PR DESCRIPTION
Fixes the `nitrogen::build` command to look for the Dockerfile in the provided `dockerfile_dir` argument. Also adds a few slightly better log/error messages elsewhere